### PR TITLE
Update peering policy for AS211224

### DIFF
--- a/src/pages/as211224.md
+++ b/src/pages/as211224.md
@@ -10,4 +10,4 @@ You can find more information and see the currently announced routes on [bgp.too
 
 # Peering Policy
 
-AS211224 is present on [RapidIX](https://rapidix.net/) and is a routeserver peer. You can find mutual points on PeeringDB [here](https://www.peeringdb.com/net/27107). Please contact [joe@jb3.dev](mailto:joe@jb3.dev) for peering questions, or find other contact points on PeeringDB.
+AS211224 is a routeserver peer. You can find mutual points on PeeringDB [here](https://www.peeringdb.com/net/27107). Please contact [joe@jb3.dev](mailto:joe@jb3.dev) for peering questions, or find other contact points on PeeringDB.

--- a/src/pages/as211224.md
+++ b/src/pages/as211224.md
@@ -10,4 +10,4 @@ You can find more information and see the currently announced routes on [bgp.too
 
 # Peering Policy
 
-AS211224 is a routeserver peer. You can find mutual points on PeeringDB [here](https://www.peeringdb.com/net/27107). Please contact [joe@jb3.dev](mailto:joe@jb3.dev) for peering questions, or find other contact points on PeeringDB.
+You can find mutual points on PeeringDB [here](https://www.peeringdb.com/net/27107). Please contact [joe@jb3.dev](mailto:joe@jb3.dev) for peering questions, or find other contact points on PeeringDB.


### PR DESCRIPTION
Removed mention of RapidIX from peering policy. Link is dead.